### PR TITLE
stream: reuse buffers

### DIFF
--- a/beater/route_config.go
+++ b/beater/route_config.go
@@ -225,8 +225,11 @@ func (v v2Route) Handler(url string, c *Config, report publish.Reporter) http.Ha
 	)
 
 	v2Handler := v2Handler{
-		requestDecoder:  reqDecoder,
-		streamProcessor: &stream.StreamProcessor{Tconfig: v.transformConfig(c)},
+		requestDecoder: reqDecoder,
+		streamProcessor: &stream.StreamProcessor{
+			Tconfig:      v.transformConfig(c),
+			MaxEventSize: c.MaxEventSize,
+		},
 	}
 
 	if url == V2RumURL {

--- a/decoder/line_reader.go
+++ b/decoder/line_reader.go
@@ -28,16 +28,14 @@ var ErrLineTooLong = errors.New("Line exceeded permitted length")
 
 // LineReader reads length-limited lines from streams using a limited amount of memory.
 type LineReader struct {
-	reader        io.Reader
 	br            *bufio.Reader
 	maxLineLength int
 	skip          bool
 }
 
-func NewLineReader(reader io.Reader, maxLineLength int) *LineReader {
+func NewLineReader(reader *bufio.Reader, maxLineLength int) *LineReader {
 	return &LineReader{
-		reader:        reader,
-		br:            bufio.NewReaderSize(reader, maxLineLength),
+		br:            reader,
 		maxLineLength: maxLineLength,
 	}
 }

--- a/decoder/line_reader_test.go
+++ b/decoder/line_reader_test.go
@@ -18,6 +18,7 @@
 package decoder
 
 import (
+	"bufio"
 	"bytes"
 	"io"
 	"testing"
@@ -28,7 +29,7 @@ import (
 
 func TestLineReaderEmpty(t *testing.T) {
 	readBuf := bytes.NewBufferString("")
-	lr := NewLineReader(readBuf, 10)
+	lr := NewLineReader(bufio.NewReaderSize(readBuf, 10), 10)
 
 	buf, err := lr.ReadLine()
 	assert.Equal(t, io.EOF, err)
@@ -43,7 +44,7 @@ func TestLineReader(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nline2\n01234567890123456789\nline4\nline5")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -76,7 +77,7 @@ func TestLineReaderEndWithNewline(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nline2\n01234567890123456789\nline4\nline5\n")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -112,7 +113,7 @@ func TestLineReaderTwoLongLines(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nlong-string-with-no-newlines-at-all\nanother-long-string-with-no-newlines-at-all\nline2")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -140,7 +141,7 @@ func TestLineReaderNoLines(t *testing.T) {
 		iotest.DataErrReader,
 	} {
 		readBuf := bytes.NewBufferString("line1\nlong-string-with-no-newlines-at-all\nanother-long-string-with-no-newlines-at-all")
-		lr := NewLineReader(r(readBuf), 10)
+		lr := NewLineReader(bufio.NewReaderSize(r(readBuf), 10), 10)
 
 		buf, err := lr.ReadLine()
 		assert.NoError(t, err)
@@ -179,7 +180,7 @@ func TestLineReaderDeadline(t *testing.T) {
 	readBuf := bytes.NewBufferString("line1\nline2\nlong-string-with-no-newlines-at-all")
 	reader := DeadlineReader(readBuf)
 
-	lr := NewLineReader(reader, 10)
+	lr := NewLineReader(bufio.NewReaderSize(reader, 10), 10)
 
 	buf, err := lr.ReadLine()
 	assert.NoError(t, err)
@@ -201,7 +202,7 @@ func TestLineReaderDeadline(t *testing.T) {
 func TestLineReaderShort(t *testing.T) {
 	readBuf := bytes.NewBufferString("line1\nline2")
 
-	lr := NewLineReader(readBuf, 1024)
+	lr := NewLineReader(bufio.NewReaderSize(readBuf, 1024), 1024)
 
 	buf, err := lr.ReadLine()
 	assert.NoError(t, err)

--- a/decoder/stream_decoder.go
+++ b/decoder/stream_decoder.go
@@ -19,29 +19,12 @@ package decoder
 
 import (
 	"bytes"
-	"fmt"
 	"io"
 	"io/ioutil"
-	"net/http"
-	"strings"
 )
 
-func NDJSONStreamDecodeCompressedWithLimit(req *http.Request, lineLimit int) (*NDJSONStreamReader, error) {
-	contentType := req.Header.Get("Content-Type")
-	if !strings.Contains(contentType, "application/x-ndjson") {
-		return nil, fmt.Errorf("invalid content type: '%s'", req.Header.Get("Content-Type"))
-	}
-
-	reader, err := CompressedRequestReader(req)
-	if err != nil {
-		return nil, err
-	}
-
-	return NewNDJSONStreamReader(reader, lineLimit), nil
-}
-
-func NewNDJSONStreamReader(reader io.Reader, lineLimit int) *NDJSONStreamReader {
-	return &NDJSONStreamReader{reader: NewLineReader(reader, lineLimit)}
+func NewNDJSONStreamReader(reader *LineReader) *NDJSONStreamReader {
+	return &NDJSONStreamReader{reader: reader}
 }
 
 type NDJSONStreamReader struct {

--- a/decoder/stream_decoder_test.go
+++ b/decoder/stream_decoder_test.go
@@ -18,6 +18,7 @@
 package decoder
 
 import (
+	"bufio"
 	"bytes"
 	"strings"
 	"testing"
@@ -61,7 +62,7 @@ func TestNDStreamReader(t *testing.T) {
 		},
 	}
 	buf := bytes.NewBufferString(strings.Join(lines, "\n"))
-	n := NewNDJSONStreamReader(buf, 20)
+	n := NewNDJSONStreamReader(NewLineReader(bufio.NewReaderSize(buf, 20), 20))
 
 	for idx, test := range expected {
 		out, err := n.Read()

--- a/processor/stream/benchmark_test.go
+++ b/processor/stream/benchmark_test.go
@@ -22,12 +22,9 @@ import (
 	"context"
 	"errors"
 	"io/ioutil"
-	"math"
 	"path/filepath"
 	"runtime"
 	"testing"
-
-	r "golang.org/x/time/rate"
 
 	"github.com/elastic/apm-server/publish"
 	"github.com/elastic/apm-server/tests/loader"
@@ -47,8 +44,8 @@ func BenchmarkStreamProcessor(b *testing.B) {
 		b.Error(err)
 	}
 	//ensure to not hit rate limit as blocking wait would be measured otherwise
-	rl := r.NewLimiter(r.Limit(math.MaxFloat64-1), math.MaxInt32)
-	sp := &StreamProcessor{MaxEventSize: 100000}
+	// rl := r.NewLimiter(r.Limit(math.MaxFloat64-1), math.MaxInt32)
+	sp := &StreamProcessor{MaxEventSize: 300 * 1024}
 	for _, f := range files {
 		b.Run(f.Name(), func(b *testing.B) {
 			data, err := loader.LoadDataAsBytes(filepath.Join(dir, f.Name()))
@@ -63,7 +60,7 @@ func BenchmarkStreamProcessor(b *testing.B) {
 				b.StopTimer()
 				r.Reset(data)
 				b.StartTimer()
-				sp.HandleStream(context.Background(), rl, map[string]interface{}{}, ioutil.NopCloser(r), report)
+				sp.HandleStream(context.Background(), nil, map[string]interface{}{}, r, report)
 			}
 		})
 	}

--- a/processor/stream/package_tests/error_attrs_test.go
+++ b/processor/stream/package_tests/error_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func errorProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/errors.ndjson",
 		TemplatePaths: []string{
 			"../../../model/error/_meta/fields.yml",

--- a/processor/stream/package_tests/metadata_attrs_test.go
+++ b/processor/stream/package_tests/metadata_attrs_test.go
@@ -18,6 +18,7 @@
 package package_tests
 
 import (
+	"bufio"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -82,7 +83,8 @@ func getMetadataEventAttrs(t *testing.T, prefix string) *tests.Set {
 	payloadStream, err := loader.LoadDataAsStream("../testdata/intake-v2/only-metadata.ndjson")
 	require.NoError(t, err)
 
-	metadata, err := decoder.NewNDJSONStreamReader(payloadStream, 100*1024).Read()
+	lr := decoder.NewLineReader(bufio.NewReader(payloadStream), lrSize)
+	metadata, err := decoder.NewNDJSONStreamReader(lr).Read()
 	require.NoError(t, err)
 
 	contextMetadata := metadata["metadata"]

--- a/processor/stream/package_tests/metricset_attrs_test.go
+++ b/processor/stream/package_tests/metricset_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func metricsetProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/metricsets.ndjson",
 		TemplatePaths: []string{
 			"../../../model/metricset/_meta/fields.yml",

--- a/processor/stream/package_tests/span_attrs_test.go
+++ b/processor/stream/package_tests/span_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func spanProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/spans.ndjson",
 		Schema:          schema.ModelSchema,
 		SchemaPrefix:    "span",

--- a/processor/stream/package_tests/transaction_attrs_test.go
+++ b/processor/stream/package_tests/transaction_attrs_test.go
@@ -28,7 +28,7 @@ import (
 
 func transactionProcSetup() *tests.ProcessorSetup {
 	return &tests.ProcessorSetup{
-		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{}},
+		Proc:            &V2TestProcessor{StreamProcessor: stream.StreamProcessor{MaxEventSize: lrSize}},
 		FullPayloadPath: "../testdata/intake-v2/transactions.ndjson",
 		Schema:          schema.ModelSchema,
 		SchemaPrefix:    "transaction",


### PR DESCRIPTION
After our call a couple of days ago where it was pointed out how the 300kb buffer for the line reader gets allocated up front I had a sort of nightmare about the overhead per http request to the APM Server and wanted to look into if it was worth to reuse the buffers between requests. For large requests, the cost of the allocation is not significant, but for many small requests there is a speedup. 

While experimenting, I took the rate limiting out of the benchmark and changed it to use the 300kb default line length, as you can see below.  Rate limiting is only in effect in RUM, so the number here would correspond to the data from backend agents. 

This change makes the code more complex and I expect the overhead in beats for JSON serializing etc. (which are not measured in this benchmark) might make the gains here less attractive, but it's worth a discussion. 

**ns/op:**
```
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkStreamProcessor/errors.ndjson-4                    280910        200638        -28.58%
BenchmarkStreamProcessor/events.ndjson-4                    146007        88538         -39.36%
BenchmarkStreamProcessor/heavy.ndjson-4                     24615514      25014177      +1.62%
```

**MB/s:**
```
benchmark                                                   old MB/s     new MB/s     speedup
BenchmarkStreamProcessor/errors.ndjson-4                    15.67        21.94        1.40x
BenchmarkStreamProcessor/events.ndjson-4                    6.90         11.37        1.65x
BenchmarkStreamProcessor/heavy.ndjson-4                     16.19        15.93        0.98x
```



<details>

```
$ benchcmp old.txt new.txt
benchmark                                                   old ns/op     new ns/op     delta
BenchmarkStreamProcessor/errors.ndjson-4                    280910        200638        -28.58%
BenchmarkStreamProcessor/events.ndjson-4                    146007        88538         -39.36%
BenchmarkStreamProcessor/heavy.ndjson-4                     24615514      25014177      +1.62%
BenchmarkStreamProcessor/invalid-event.ndjson-4             121174        61915         -48.90%
BenchmarkStreamProcessor/invalid-json-event.ndjson-4        98437         43323         -55.99%
BenchmarkStreamProcessor/invalid-json-metadata.ndjson-4     46482         7196          -84.52%
BenchmarkStreamProcessor/invalid-metadata-2.ndjson-4        44754         6398          -85.70%
BenchmarkStreamProcessor/invalid-metadata.ndjson-4          52331         11085         -78.82%
BenchmarkStreamProcessor/metadata-null-values.ndjson-4      101302        41591         -58.94%
BenchmarkStreamProcessor/metricsets.ndjson-4                131967        74594         -43.48%
BenchmarkStreamProcessor/minimal-service.ndjson-4           98320         43179         -56.08%
BenchmarkStreamProcessor/only-metadata.ndjson-4             89040         39160         -56.02%
BenchmarkStreamProcessor/optional-timestamps.ndjson-4       138138        83302         -39.70%
BenchmarkStreamProcessor/ratelimit.ndjson-4                 374608        296282        -20.91%
BenchmarkStreamProcessor/spans.ndjson-4                     221895        160157        -27.82%
BenchmarkStreamProcessor/transactions.ndjson-4              214398        158546        -26.05%
BenchmarkStreamProcessor/unrecognized-event.ndjson-4        75768         29123         -61.56%

benchmark                                                   old MB/s     new MB/s     speedup
BenchmarkStreamProcessor/errors.ndjson-4                    15.67        21.94        1.40x
BenchmarkStreamProcessor/events.ndjson-4                    6.90         11.37        1.65x
BenchmarkStreamProcessor/heavy.ndjson-4                     16.19        15.93        0.98x
BenchmarkStreamProcessor/invalid-event.ndjson-4             6.32         12.37        1.96x
BenchmarkStreamProcessor/invalid-json-event.ndjson-4        5.96         13.55        2.27x
BenchmarkStreamProcessor/invalid-json-metadata.ndjson-4     9.85         63.64        6.46x
BenchmarkStreamProcessor/invalid-metadata-2.ndjson-4        10.01        70.01        6.99x
BenchmarkStreamProcessor/invalid-metadata.ndjson-4          8.73         41.23        4.72x
BenchmarkStreamProcessor/metadata-null-values.ndjson-4      4.91         11.95        2.43x
BenchmarkStreamProcessor/metricsets.ndjson-4                6.71         11.88        1.77x
BenchmarkStreamProcessor/minimal-service.ndjson-4           4.32         9.84         2.28x
BenchmarkStreamProcessor/only-metadata.ndjson-4             6.28         14.27        2.27x
BenchmarkStreamProcessor/optional-timestamps.ndjson-4       7.43         12.33        1.66x
BenchmarkStreamProcessor/ratelimit.ndjson-4                 11.24        14.22        1.27x
BenchmarkStreamProcessor/spans.ndjson-4                     11.97        16.58        1.39x
BenchmarkStreamProcessor/transactions.ndjson-4              13.18        17.82        1.35x
BenchmarkStreamProcessor/unrecognized-event.ndjson-4        5.16         13.43        2.60x

benchmark                                                   old allocs     new allocs     delta
BenchmarkStreamProcessor/errors.ndjson-4                    946            943            -0.32%
BenchmarkStreamProcessor/events.ndjson-4                    377            374            -0.80%
BenchmarkStreamProcessor/heavy.ndjson-4                     134559         134556         -0.00%
BenchmarkStreamProcessor/invalid-event.ndjson-4             270            266            -1.48%
BenchmarkStreamProcessor/invalid-json-event.ndjson-4        199            196            -1.51%
BenchmarkStreamProcessor/invalid-json-metadata.ndjson-4     29             27             -6.90%
BenchmarkStreamProcessor/invalid-metadata-2.ndjson-4        24             22             -8.33%
BenchmarkStreamProcessor/invalid-metadata.ndjson-4          52             49             -5.77%
BenchmarkStreamProcessor/metadata-null-values.ndjson-4      178            175            -1.69%
BenchmarkStreamProcessor/metricsets.ndjson-4                296            293            -1.01%
BenchmarkStreamProcessor/minimal-service.ndjson-4           201            198            -1.49%
BenchmarkStreamProcessor/only-metadata.ndjson-4             212            209            -1.42%
BenchmarkStreamProcessor/optional-timestamps.ndjson-4       388            385            -0.77%
BenchmarkStreamProcessor/ratelimit.ndjson-4                 1448           1444           -0.28%
BenchmarkStreamProcessor/spans.ndjson-4                     767            764            -0.39%
BenchmarkStreamProcessor/transactions.ndjson-4              657            654            -0.46%
BenchmarkStreamProcessor/unrecognized-event.ndjson-4        128            126            -1.56%

benchmark                                                   old bytes     new bytes     delta
BenchmarkStreamProcessor/errors.ndjson-4                    361917        55556         -84.65%
BenchmarkStreamProcessor/events.ndjson-4                    334515        25106         -92.49%
BenchmarkStreamProcessor/heavy.ndjson-4                     7744681       7452358       -3.77%
BenchmarkStreamProcessor/invalid-event.ndjson-4             327101        17011         -94.80%
BenchmarkStreamProcessor/invalid-json-event.ndjson-4        324075        13841         -95.73%
BenchmarkStreamProcessor/invalid-json-metadata.ndjson-4     313344        2157          -99.31%
BenchmarkStreamProcessor/invalid-metadata-2.ndjson-4        313184        1987          -99.37%
BenchmarkStreamProcessor/invalid-metadata.ndjson-4          314585        3320          -98.94%
BenchmarkStreamProcessor/metadata-null-values.ndjson-4      322977        12370         -96.17%
BenchmarkStreamProcessor/metricsets.ndjson-4                330364        20481         -93.80%
BenchmarkStreamProcessor/minimal-service.ndjson-4           325331        15142         -95.35%
BenchmarkStreamProcessor/only-metadata.ndjson-4             325320        15047         -95.37%
BenchmarkStreamProcessor/optional-timestamps.ndjson-4       334785        25205         -92.47%
BenchmarkStreamProcessor/ratelimit.ndjson-4                 393111        86351         -78.03%
BenchmarkStreamProcessor/spans.ndjson-4                     353608        46186         -86.94%
BenchmarkStreamProcessor/transactions.ndjson-4              349446        41338         -88.17%
BenchmarkStreamProcessor/unrecognized-event.ndjson-4        321277        10633         -96.69%
```

</details>

Builds on https://github.com/elastic/apm-server/pull/1473